### PR TITLE
Initial DB layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SQlite DB files
+/*.db
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Caveats

- Just SQLite right now, for simplicity
- Still using reentrant locks, due to `sqlite3` module not being threadsafe. They have a threadsafety parameter but in the interest of getting this done quickly didn't dig into it much.