### PR TITLE
Add websocket api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ sniffio==1.3.0
 starlette==0.27.0
 typing_extensions==4.6.3
 uvicorn==0.22.0
+websockets==11.0.3


### PR DESCRIPTION
WebSocket endpoint that accepts regular `CompletionInferenceRequest` JSON payloads.

It accepts one message, streams the response tokens, and then closes the websocket in the current implementation.