### PR TITLE
Improvements to Layout

### DIFF
--- a/frontend/src/components/core/Widget.tsx
+++ b/frontend/src/components/core/Widget.tsx
@@ -14,7 +14,7 @@ export default function Widget(
     }
 ){
     return (
-        <div className="flex flex-col w-full outline outline-2 outline-dark-400 rounded-md divide-dark-400 divide-y-2">
+        <div className="flex flex-col w-full outline outline-2 outline-dark-400 rounded-md divide-dark-400 divide-y-2 mb-5">
             <div className="flex flex-row w-full items-center p-2 gap-2 bg-dark-200">
                 {(icon ? (
                     <div className="">

--- a/frontend/src/components/layout/OneColumnLayout.tsx
+++ b/frontend/src/components/layout/OneColumnLayout.tsx
@@ -1,0 +1,15 @@
+export default function OneColumnLayout(
+    {
+        colOneContent,
+    } : {
+        colOneContent?: React.ReactNode | React.ReactNode[],
+    }
+) {
+    return (
+        <div className="flex flex-row w-full gap-5 pb-5">
+            <div className="w-full">
+                {colOneContent ? colOneContent : null}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/components/layout/Page.tsx
+++ b/frontend/src/components/layout/Page.tsx
@@ -1,0 +1,13 @@
+export default function Page(
+    {
+        children
+    } : {
+        children: React.ReactNode | React.ReactNode[],
+    }
+) {
+    return (
+        <div className="w-10/12 h-full pt-5 mx-auto">
+            {children}
+        </div>
+    )
+}

--- a/frontend/src/components/layout/TwoColumnLayout.tsx
+++ b/frontend/src/components/layout/TwoColumnLayout.tsx
@@ -1,0 +1,31 @@
+export default function TwoColumnLayout(
+    {
+        colOneContent,
+        colTwoContent,
+        type
+    } : {
+        colOneContent?: React.ReactNode | React.ReactNode[],
+        colTwoContent?: React.ReactNode | React.ReactNode[],
+        type: "left" | "right" | "equal"
+    }
+) {
+    const typeOptions = {
+        left:  ["w-2/3", "w-1/3"],
+        right: ["w-1/3", "w-2/3"],
+        equal: ["w-1/2", "w-1/2"]
+    }
+
+    return (
+        <div className="flex flex-row w-full gap-5 pb-5">
+
+            <div className={`${typeOptions[type][0]}`}>
+                {colOneContent ? colOneContent : null}
+            </div>
+
+            <div className={`${typeOptions[type][1]}`}>
+                {colTwoContent? colTwoContent : null}
+            </div>
+
+        </div>
+    )
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,9 +4,12 @@ import { Dialog, Transition } from '@headlessui/react'
 import { useGetModelsQuery, useRegisterModelMutation } from '../services/baseService'
 import { GetRegisteredModelsResponse, ModelInfo, ModelType } from '../api'
 
-import Section from '../components/core/Section'
 import Callout from '../components/core/Callout'
 import ModelCardView from '../components/ModelCardView'
+import Page from '../components/layout/Page'
+import OneColumnLayout from '../components/layout/OneColumnLayout'
+import TwoColumnLayout from '../components/layout/TwoColumnLayout'
+import Widget from '../components/core/Widget'
 
 interface distinctModel {
   name: string,
@@ -182,7 +185,7 @@ export default function Home() {
 
     const distinctModelList = new Array<distinctModel>();
 
-    if(!data) {return distinctModelList}
+    if (!data) { return distinctModelList }
 
     for (const model of data.models) {
       let flag = true;
@@ -214,7 +217,7 @@ export default function Home() {
   let distinctModelList: distinctModel[] = [];
 
   if (error) { console.log(error) }
-  if (!isLoading && data) {distinctModelList = getAllModels(data)}
+  if (!isLoading && data) { distinctModelList = getAllModels(data) }
 
   return (
     <>
@@ -224,84 +227,84 @@ export default function Home() {
       }}
       />
 
-      <div className='mt-10 w-[80%] self-center'>
-        <div className="flex flex-col gap-5 items-center">
+      <Page>
 
-          <Callout>
-            <h3 className='text-lg font-semibold text-dark-500 leading-none'>Welcome to Intrinsic Model Server</h3>
-            <p className='text-lg text-dark-500 leading-snug mt-2'>
-              This project is under active development by members of <a href="https://intrinsiclabs.ai" target="_blank" className='underline underline-offset-2'>Intrinsic Labs</a>.
-              If you have any issues or ideas, add them as issues to the <a href="https://github.com/IntrinsicLabsAI/intrinsic-model-server" target="_blank" className='underline underline-offset-2'>GitHub repository</a>.
-              A roadmap for this project is available in the GitHub repository.
-            </p>
-          </Callout>
+        <OneColumnLayout
+          colOneContent={
+            <Callout>
+              <h3 className='text-lg font-semibold text-dark-500 leading-none'>Welcome to Intrinsic Model Server</h3>
+              <p className='text-lg text-dark-500 leading-snug mt-2'>
+                This project is under active development by members of <a href="https://intrinsiclabs.ai" target="_blank" className='underline underline-offset-2'>Intrinsic Labs</a>.
+                If you have any issues or ideas, add them as issues to the <a href="https://github.com/IntrinsicLabsAI/intrinsic-model-server" target="_blank" className='underline underline-offset-2'>GitHub repository</a>.
+                A roadmap for this project is available in the GitHub repository.
+              </p>
+            </Callout>
+          } />
 
-          <div className='flex flex-row w-full gap-5'>
+        <TwoColumnLayout
+          type="left"
+          colOneContent={
+            <>
+              <Widget title="Registered Models">
+                <div className="flex flex-col h-full">
+                  <div className="flex flex-row items-center w-full">
+                    <p className=' text-lg font-base text-slate-600 leading-tight text-white/70'>
+                      The models listed below are currently active and available for use.
+                      Different versions of each model can be used by indicating the version when invoking the model.
+                    </p>
+                  </div>
 
-            <Section>
-              <div className="flex flex-col h-full">
-                <h3 className="text-3xl font-semibold grow text-white/90">Registered Models</h3>
-                <div className="flex flex-row items-center w-full mt-2">
-                  <p className=' text-lg font-base text-slate-600 leading-tight mt-2 text-white/70'>
-                    The models listed below are currently active and available for use.
-                    Different versions of each model can be used by indicating the version when invoking the model.
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-2 gap-4 w-full mt-8 mx-auto">
-                  {(!isLoading && data) ? (
-                    distinctModelList.map((model) => (
-                      <div key={model.name} className=" w-full ">
-                        <ModelCardView 
-                          modelName={model.name}
+                  <div className="grid grid-cols-1 gap-4 w-10/12 mt-4 mx-auto">
+                    {(!isLoading && data) ? (
+                      distinctModelList.map((model) => (
+                        <div key={model.name} className=" w-full ">
+                          <ModelCardView
+                            modelName={model.name}
                           />
-                      </div>
-                    ))) : ( 
-                      null 
+                        </div>
+                      ))) : (
+                      null
                     )}
+                  </div>
                 </div>
-              </div>
-            </Section>
+              </Widget>
+            </>
+          }
+          colTwoContent={
+            <>
+              <Widget title="Server Status">
+                <div className='flex flex-col items-center'>
+                  <p className=' text-white font-semibold '>Current Status</p>
+                  {(!error) ? (
+                    <div className='flex flex-row items-center gap-2'>
+                      <div className="w-4 h-4 bg-primary-600 rounded-full"></div>
+                      <p className=' text-lg font-bold text-primary-600'>Online</p>
+                    </div>
+                  ) : (
+                    <div className='flex flex-row items-center gap-2'>
+                      <div className="w-4 h-4 bg-white rounded-full"></div>
+                      <p className=' text-lg font-bold text-white'>Offline</p>
+                    </div>
+                  )}
+                </div>
+              </Widget>
 
-            <div className=' flex flex-col w-80 gap-5'>
-              <div className='grow-0'>
-                <Section>
-                  <div className='flex flex-col items-center'>
-                    <p className=' text-white font-semibold '>Server Status</p>
-                    {(!error) ? (
-                      <div className='flex flex-row items-center gap-2'>
-                        <div className="w-4 h-4 bg-primary-600 rounded-full"></div>
-                        <p className=' text-lg font-bold text-primary-600'>Online</p>
-                      </div>
-                    ) : (
-                      <div className='flex flex-row items-center gap-2'>
-                        <div className="w-4 h-4 bg-white rounded-full"></div>
-                        <p className=' text-lg font-bold text-white'>Offline</p>
-                      </div>
-                    )}
-                  </div>
-                </Section>
-              </div>
-
-              <div className='grow-0'>
-                <Section>
-                  <div className='flex flex-col items-center'>
-                    <p className=' text-white font-semibold'>Quick Actions</p>
-                    <button
-                      type='button'
-                      onClick={() => setOpen(true)}
-                      className=' hover:text-primary-400 rounded pt-2'>
-                      <p className=' text-base text-white'>Register Model</p>
-                    </button>
-                  </div>
-                </Section>
-              </div>
-
-            </div>
-          </div>
-        </div>
-      </div>
-
+              <Widget title="Quick Actions">
+                <div className='flex flex-col items-center'>
+                  <p className=' text-white font-semibold'>Actions Available</p>
+                  <button
+                    type='button'
+                    onClick={() => setOpen(true)}
+                    className=' hover:text-primary-400 rounded pt-2'>
+                    <p className='text-base text-white hover:text-primary-400 hover:font-semibold'>Register Model</p>
+                    <p className='text-base text-white hover:text-primary-400 hover:font-semibold'>View Documentation</p>
+                  </button>
+                </div>
+              </Widget>
+            </>
+          }
+        />
+      </Page>
     </>
   )
 }

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,5 +1,4 @@
-// import { Routes, Route, Navigate } from 'react-router-dom';
-import { Outlet } from 'react-router-dom';
+import { Outlet, Link } from 'react-router-dom';
 import { BookOpenIcon } from '@heroicons/react/24/solid'
 
 export default function Workspace() {
@@ -8,7 +7,9 @@ export default function Workspace() {
             <div className="flex flex-col h-screen">
                 <header>
                     <div className='flex flex-row h-18 p-4 items-center bg-dark-200'>
-                        <p className="text-lg font-semibold">Model Server</p>
+                        <Link to="/">
+                            <p className="text-lg font-semibold">Model Server</p>
+                        </Link>
                         <a aria-label="View Server API Documentatio." className='ml-auto' href='http://127.0.0.1:8000/docs' rel="noopener" target="_blank">
                             <BookOpenIcon className="h-8 w-8 text-gray-400 pr-2" />
                         </a>


### PR DESCRIPTION
**This commit adds the following:**

- New Layout components (/components/layout) which allows us to rapidly build new page layouts with three basic components with the ability to extend the layouts in the future as needed
- Adds Link when you click the name of the site to bring you back to homepage
- Migrates the homepage from Sections to new Layout components (Page + OneColumnLayout + Two ColumnLayout)
- Adds "default" padding to the bottom of each widget of 5, this is the default we now use between each column in the layout components as well

**Some things to do from here:**
- Add additional design flexibility to Widget component
- Rethink some of the baseline color choices for boarders + background to refine darkmode
- Add "Header" section to page which will allow for github style wide page header sections
- Add additional flexibility to One and Two Column components to allow for additional customization
- Add better responsive controls to One and Two Column components
- Build header component to use as a baseline for that section (need to think about this)