### PR TITLE
Continuously refresh health on Homepage

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -10,5 +10,6 @@ module.exports = {
   plugins: ['react-refresh'],
   rules: {
     'react-refresh/only-export-components': 'warn',
-  },
+    "@typescript-eslint/no-unused-vars": ["warn", { "ignoreRestSiblings": true }],
+  }
 }

--- a/frontend/src/api/services/baseService.ts
+++ b/frontend/src/api/services/baseService.ts
@@ -1,8 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { GetRegisteredModelsResponse, ModelInfo } from '..';
-
-
-const isDevServer = window.location.host.endsWith(":5173");
+import { isDevServer } from './util';
 
 export const baseServiceAPI = createApi({
   reducerPath: 'baseServiceAPI',
@@ -10,7 +8,7 @@ export const baseServiceAPI = createApi({
     "models",
     "description",
   ],
-  baseQuery: fetchBaseQuery({ baseUrl: isDevServer ? "http://0.0.0.0:8000/v1" : '/v1' }),
+  baseQuery: fetchBaseQuery({ baseUrl: isDevServer() ? "http://0.0.0.0:8000/v1" : '/v1' }),
   endpoints: (builder) => ({
     getModels: builder.query<GetRegisteredModelsResponse, void>({
       query: () => `models`,
@@ -32,13 +30,13 @@ export const baseServiceAPI = createApi({
       }),
     }),
     getDescription: builder.query<string, string>({
-      providesTags: (_result, _error, query) => [{type: "description", id: query}],
+      providesTags: (_result, _error, query) => [{ type: "description", id: query }],
       query: (modelName) => ({
         url: `${modelName}/description`,
       }),
     }),
     updateDescription: builder.mutation<string | undefined, { modelName: string, description: string }>({
-      invalidatesTags: (_result, _error, query) => [{type: "description", id: query.modelName}],
+      invalidatesTags: (_result, _error, query) => [{ type: "description", id: query.modelName }],
       query: ({ modelName, description }) => ({
         url: `${modelName}/description`,
         method: "PUT",

--- a/frontend/src/api/services/statusService.ts
+++ b/frontend/src/api/services/statusService.ts
@@ -1,0 +1,54 @@
+import { isDevServer } from "./util";
+
+/**
+ * Status service allows for a simple status checking mechanism.
+ */
+const pollStatus = async () => {
+    const abort = new AbortController();
+    const healthz = isDevServer() ? "//127.0.0.1:8000/healthz" : "/healthz";
+
+    setTimeout(() => abort.abort("timed out"), 2_000);
+
+    const result = await fetch(healthz, { signal: abort.signal })
+        .then(resp => resp.status)
+        .catch(() => 500);
+    return result === 200;
+};
+
+export type Status = "loading" | "online" | "offline";
+
+export class StatusChecker {
+    private timerId = -1;
+
+    public status: Status = "loading";
+
+    constructor(
+        private onPoll: (value: Status) => void,
+    ) { }
+
+    start() {
+        this.loop();
+    }
+
+    private loop() {
+        console.log("next poll");
+        pollStatus()
+            .then(isConnected => {
+                this.onPoll(isConnected ? "online" : "offline");
+                this.status = isConnected ? "online" : "offline";
+            }).catch(() => {
+                this.onPoll("offline");
+                this.status = "offline";
+            })
+            .finally(() => {
+                console.log("scheduling next poll");
+                this.timerId = setTimeout(() => this.loop(), 3_000);
+            })
+    }
+
+    stop() {
+        if (this.timerId >= 0) {
+            clearTimeout(this.timerId);
+        }
+    }
+}

--- a/frontend/src/components/core/EditableCode.tsx
+++ b/frontend/src/components/core/EditableCode.tsx
@@ -36,9 +36,9 @@ const EditableCode = React.memo(({
                         }} language={langage} />
                         : <ReactMarkdown
                             components={{
-                                h1: ({ ...props }) => (<p className="text-xl underline" {...props} />),
-                                h2: ({ ...props }) => (<p className="text-md underline" {...props} />),
-                                p: ({ ...props }) => (<p className="text-sm" {...props} />),
+                                h1: ({ node, ...props }) => (<p className="text-xl underline" {...props} />),
+                                h2: ({ node, ...props }) => (<p className="text-md underline" {...props} />),
+                                p: ({ node, ...props }) => (<p className="text-sm" {...props} />),
                             }}
                             children={code || "Nothing"}
                             disallowedElements={["img", "script"]}

--- a/frontend/src/components/core/Pill.tsx
+++ b/frontend/src/components/core/Pill.tsx
@@ -6,15 +6,15 @@ export default function Pill(
         text: string,
         color?: "blue" | "purple" | "primary"
     }) {
-    
+
     const colors = {
         blue: "bg-blue-200",
         purple: "bg-purple-200",
         primary: "bg-primary-200",
     }
-    
+
     return (
-        <div className={`${color ? colors[color] : "bg-primary-200"} px-3 py-1.5 rounded-3xl`}>
+        <div className={`${colors[color || "primary"]} px-3 py-1.5 rounded-3xl`}>
             <p className=" text-dark-200 font-bold text-sm">{text}</p>
         </div>
     )

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 
 import { useGetModelsQuery, useRegisterModelMutation } from '../api/services/baseService'
@@ -11,6 +11,7 @@ import OneColumnLayout from '../components/layout/OneColumnLayout'
 import TwoColumnLayout from '../components/layout/TwoColumnLayout'
 import Widget from '../components/core/Widget'
 import Column from '../components/layout/Column'
+import { Status, StatusChecker } from "../api/services/statusService";
 
 interface distinctModel {
   name: string,
@@ -215,6 +216,17 @@ export default function Home() {
     return distinctModelList;
   };
 
+  // Setup status checker in background.
+  const [onlineState, setOnlineState] = useState<Status>("loading");
+  useEffect(() => {
+    // Create and mount a status checker on the beginning of page load.
+    const checker = new StatusChecker(setOnlineState);
+    checker.start();
+    return () => {
+      checker.stop();
+    };
+  }, []);
+
   let distinctModelList: distinctModel[] = [];
 
   if (error) { console.log(error) }
@@ -275,9 +287,9 @@ export default function Home() {
                 ) : (
                   <div className="mt-2">
                     <p className=''>
-                       No models were found. 
-                       This could be because no models have been registered or the server is offline.
-                       To get started, please register a model.
+                      No models were found.
+                      This could be because no models have been registered or the server is offline.
+                      To get started, please register a model.
                     </p>
                   </div>
                 )}
@@ -285,20 +297,29 @@ export default function Home() {
               </div>
             </Widget>
           </Column>
-          
+
           <Column>
             <Widget title="Server Status">
               <div className='flex flex-col items-center'>
                 <p className=' text-white font-semibold '>Current Status</p>
-                {(!error) ? (
+                {
+                  onlineState === "loading" && (
+                    <div className='flex flex-row items-center gap-2'>
+                      <div className="w-4 h-4 bg-amber-600 rounded-full"></div>
+                      <p className=' text-lg font-bold text-amber-400'>Connecting</p>
+                    </div>
+                  )
+                }
+                {onlineState === "online" && (
                   <div className='flex flex-row items-center gap-2'>
                     <div className="w-4 h-4 bg-primary-600 rounded-full"></div>
-                    <p className=' text-lg font-bold text-primary-600'>Online</p>
+                    <p className=' text-lg font-bold text-primary-400'>Online</p>
                   </div>
-                ) : (
+                )}
+                {onlineState === "offline" && (
                   <div className='flex flex-row items-center gap-2'>
-                    <div className="w-4 h-4 bg-red-400 rounded-full"></div>
-                    <p className=' text-lg font-bold text-red-400'>Offline</p>
+                    <div className="w-4 h-4 bg-red-500 rounded-full"></div>
+                    <p className=' text-lg font-bold text-red-600'>Offline</p>
                   </div>
                 )}
               </div>
@@ -317,8 +338,8 @@ export default function Home() {
               </div>
             </Widget>
           </Column>
-        </TwoColumnLayout>
-      </Page>
+        </TwoColumnLayout >
+      </Page >
     </>
   )
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -259,7 +259,7 @@ export default function Home() {
             <Widget title="Registered Models">
               <div className="flex flex-col h-full">
                 <div className="flex flex-row items-center w-full">
-                  <p className=' text-lg font-base text-slate-600 leading-tight text-gray-200'>
+                  <p className=' text-lg font-base text-white leading-tight text-gray-200'>
                     The models listed below are currently active and available for use.
                     Different versions of each model can be used by indicating the version when invoking the model.
                     You can register new models here or via API.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,13 +8,6 @@ export default {
   ],
   theme: {
     extend: {
-      typography: (theme) => ({
-        DEFAULT: {
-          css: {
-            color: theme("colors.white"),
-          },
-        },
-      }),
       colors: {
         primary: {
           600: '#34ae8e',
@@ -63,6 +56,15 @@ export default {
         red: colors.red,
       },
     }
+  },
+  extend: {
+    typography: (theme) => ({
+      DEFAULT: {
+        css: {
+          color: theme("colors.white"),
+        },
+      },
+    }),
   },
   plugins: [
     require('@tailwindcss/forms'),

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,55 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 
+const colors = require("tailwindcss/colors");
+
 export default {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    colors: {
-      primary: {
-        600: '#34ae8e',
-        500: '#53b79a',
-        400: '#6cc0a6',
-        300: '#83cab2',
-        200: '#98d3bf',
-        100: '#addccb',
-      },
-      purple: {
-        600: '#978AD4'
-      },
-      red: {
-        600: '#e3144b',
-        500: '#ea435d',
-        400: '#f1616f',
-        300: '#f67a82',
-        200: '#fa9196',
-        100: '#fea8aa'
-      },
-      blue: {
-        600: '#82BEC7',
-        500: '#79a3a9',
-        400: '#89aeb4',
-        300: '#9ab9be',
-        200: '#abc5c9',
-        100: '#bbd0d3',
-      },
-      white: '#FFFFFF',
-      black: '#111418',
-      dark: {
-        100: '#1C2127',
-        200: '#252A31',
-        300: '#2F343C',
-        400: '#383E47',
-        500: '#404854',
-      },
-      gray: {
-        100: '#404854',
-        200: '#DCE0E5',
-        300: '#E5E8EB',
-        400: '#F6F7F9',
-        500: '#FAFBFC',
-      }
-    },
     extend: {
       typography: (theme) => ({
         DEFAULT: {
@@ -58,7 +15,54 @@ export default {
           },
         },
       }),
-    },
+      colors: {
+        primary: {
+          600: '#34ae8e',
+          500: '#53b79a',
+          400: '#6cc0a6',
+          300: '#83cab2',
+          200: '#98d3bf',
+          100: '#addccb',
+        },
+        purple: {
+          600: '#978AD4'
+        },
+        red: {
+          600: '#e3144b',
+          500: '#ea435d',
+          400: '#f1616f',
+          300: '#f67a82',
+          200: '#fa9196',
+          100: '#fea8aa'
+        },
+        blue: {
+          600: '#82BEC7',
+          500: '#79a3a9',
+          400: '#89aeb4',
+          300: '#9ab9be',
+          200: '#abc5c9',
+          100: '#bbd0d3',
+        },
+        white: '#FFFFFF',
+        black: '#111418',
+        dark: {
+          100: '#1C2127',
+          200: '#252A31',
+          300: '#2F343C',
+          400: '#383E47',
+          500: '#404854',
+        },
+        gray: {
+          100: '#404854',
+          200: '#DCE0E5',
+          300: '#E5E8EB',
+          400: '#F6F7F9',
+          500: '#FAFBFC',
+        },
+        amber: colors.amber,
+        red: colors.red,
+      },
+    }
   },
   plugins: [
     require('@tailwindcss/forms'),

--- a/modelserver/app.py
+++ b/modelserver/app.py
@@ -6,7 +6,17 @@ import uuid
 from abc import ABC, abstractmethod
 from enum import Enum
 from threading import RLock
-from typing import Annotated, Any, List, Optional, Tuple, Type, TypeAlias, Union
+from typing import (
+    Annotated,
+    Any,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeAlias,
+    TypedDict,
+    Union,
+)
 from uuid import UUID
 
 from fastapi import Body, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
@@ -473,6 +483,15 @@ async def update_model_description(
 @app.get("/v1/{model_name}/description")
 async def get_model_description(model_name: str) -> Optional[str]:
     return data_manager.get_model_description(model_name)
+
+
+class HealthStatus(BaseModel):
+    status: str
+
+
+@app.get("/healthz")
+async def get_healthz() -> HealthStatus:
+    return HealthStatus(status="ok")
 
 
 @app.websocket("/ws/v1/{model}/{version}/complete")


### PR DESCRIPTION
Closes #37 

* Add new `/healthz` endpoint patterned after common Kubernetes status probe naming scheme. Rather than querying the DB it just immediately responds with `{"status": "ok"}`
* Add new async `StatusChecker`
* Wire into `Home` page