### PR TITLE
Fix tailwind config for typography

### DIFF
--- a/frontend/src/components/core/EditableCode.tsx
+++ b/frontend/src/components/core/EditableCode.tsx
@@ -36,9 +36,10 @@ const EditableCode = React.memo(({
                         }} language={langage} />
                         : <ReactMarkdown
                             components={{
-                                h1: ({ node, ...props }) => (<p className="text-xl underline" {...props} />),
-                                h2: ({ node, ...props }) => (<p className="text-md underline" {...props} />),
-                                p: ({ node, ...props }) => (<p className="text-sm" {...props} />),
+                                h1: ({ node, ...props }) => (<p className="text-3xl underline" {...props} />),
+                                h2: ({ node, ...props }) => (<p className="text-xl underline" {...props} />),
+                                h3: ({ node, ...props }) => (<p className="text-lg underline" {...props} />),
+                                p: ({ node, ...props }) => (<p className="text-md" {...props} />),
                             }}
                             children={code || "Nothing"}
                             disallowedElements={["img", "script"]}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -52,19 +52,28 @@ export default {
           400: '#F6F7F9',
           500: '#FAFBFC',
         },
-        amber: colors.amber,
-        red: colors.red,
       },
-    }
-  },
-  extend: {
-    typography: (theme) => ({
-      DEFAULT: {
-        css: {
-          color: theme("colors.white"),
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': theme('colors.gray.300'),
+            '--tw-prose-headings': theme('colors.gray.200'),
+            '--tw-prose-lead': theme('colors.gray.300'),
+            '--tw-prose-links': theme('colors.cyan.500'),
+            '--tw-prose-bold': theme('colors.gray.500'),
+            '--tw-prose-counters': theme('colors.gray.300'),
+            '--tw-prose-bullets': theme('colors.gray.300'),
+            '--tw-prose-hr': theme('colors.gray.300'),
+            '--tw-prose-quotes': theme('colors.gray.200'),
+            '--tw-prose-quote-borders': theme('colors.gray.300'),
+            '--tw-prose-captions': theme('colors.gray.300'),
+            '--tw-prose-code': theme('colors.gray.200'),
+            '--tw-prose-pre-code': theme('colors.gray.500'),
+            '--tw-prose-pre-bg': theme('colors.gray.700'),
+          },
         },
-      },
-    }),
+      }),
+    }
   },
   plugins: [
     require('@tailwindcss/forms'),


### PR DESCRIPTION
The `typography` config block was in the wrong place 🤦 

Setup some default styling. This is how it looks now:

![image](https://github.com/IntrinsicLabsAI/intrinsic-model-server/assets/332583/fa5a850d-1b6a-4cdf-ae10-c43b4e01510a)
