### PR TITLE
Experiments v1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "tailwindcss": "^3.3.2",
         "typescript": "^5.0.2",
         "vite": "^4.3.9",
-        "vite-bundle-visualizer": "^0.7.0"
+        "vite-bundle-visualizer": "^0.7.0",
+        "vite-plugin-rewrite-all": "^1.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2090,6 +2091,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
@@ -6060,6 +6070,21 @@
       },
       "bin": {
         "vite-bundle-visualizer": "bin.js"
+      }
+    },
+    "node_modules/vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "dependencies": {
+        "connect-history-api-fallback": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/warning": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "tailwindcss": "^3.3.2",
     "typescript": "^5.0.2",
     "vite": "^4.3.9",
-    "vite-bundle-visualizer": "^0.7.0"
+    "vite-bundle-visualizer": "^0.7.0",
+    "vite-plugin-rewrite-all": "^1.0.1"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,13 +4,18 @@ import Workspace from './pages/Workspace';
 import NotFound from './pages/NotFound';
 import Model from './pages/Model';
 import NewModel from './pages/NewModel';
+import Overview from './pages/Model/Overview';
+import Experiments from './pages/Model/Experiments';
 
 function App() {
     return (
         <Routes>
             <Route element={<Workspace />}>
                 <Route index={true} element={<Home />} />
-                <Route path="model/:name" element={<Model />} />
+                <Route path="model/:name" element={<Model />}>
+                    <Route index element={<Overview />} />
+                    <Route path="experiments" element={<Experiments />} />
+                </Route>
                 <Route path="new-model" element={<NewModel />} />
                 <Route path="*" element={<NotFound />} />
             </Route>

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -145,7 +145,7 @@ const ExperimentView = React.memo((
                 </div>
             </div>
             <div className="flex flex-row w-full items-center">
-                <p className="leading-snug">{experiment.prompt}</p>
+                <p className="leading-snug whitespace-pre">{experiment.prompt}</p>
             </div>
 
             {isExpanded && (

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -37,12 +37,6 @@ const ExperimentInput = React.memo(({
     const [version, setVersion] = useState<string | undefined>();
     const [prompt, setPrompt] = useState<string | undefined>();
 
-    const setVersionFromMemo = (ver: string) => {
-        if (!version) {
-            setVersion(ver);
-        }
-    }
-
     const maxVersion = useMemo(() => {
         if (versions.length === 0) return undefined;
 
@@ -50,10 +44,12 @@ const ExperimentInput = React.memo(({
             .sort(semverCompare)
             .reverse()[0];
 
-        setVersionFromMemo(maxV);
+        if (!version) {
+            setVersion(maxV);
+        }
 
         return maxV;
-    }, [versions]);
+    }, [versions, version]);
 
     const [temperature, setTemperature] = useState(0.2);
     const [tokenLimit, setTokenLimit] = useState(100);

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -236,7 +236,7 @@ export default function InferenceExploration({
                 </Column>
                 <Column>
                     {experiments.length == 0 ? (
-                        <div className="flex flex-col h-full w-3/4 mx-auto items-center justify-center">
+                        <div className="flex flex-col h-5/6 w-3/4 mx-auto items-center justify-center">
                             <div className="rounded outline outline-gray-400 p-8 justify-center">
                                 <h3 className=" text-lg text-center font-semibold">Start an Experiment</h3>
                                 <p className="text-center text-gray-400/60">

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -145,7 +145,7 @@ const ExperimentView = React.memo((
                 </div>
             </div>
             <div className="flex flex-row w-full items-center">
-                <p className="leading-snug whitespace-pre">{experiment.prompt}</p>
+                <p className="leading-snug whitespace-pre-wrap">{experiment.prompt}</p>
             </div>
 
             {isExpanded && (
@@ -158,7 +158,7 @@ const ExperimentView = React.memo((
                         <Pill icon="lengthen-text" text={`${experiment.tokenLimit}`} color="purple" />
                     </div>
                     <div className="flex flex-row w-full items-center">
-                        <p className="leading-snug font-mono text-sm whitespace-pre-line">
+                        <p className="leading-snug font-mono text-sm whitespace-pre-wrap">
                             {output}
                         </p>
                     </div>

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -6,7 +6,7 @@ import { useGetModelsQuery } from "../api/services/v1";
 
 import { Icon } from "@blueprintjs/core";
 
-import Widget from "./core/Widget";
+import Card from "./core/Card";
 import Dropdown from "./core/Dropdown";
 import Column from "./layout/Column";
 import TwoColumnLayout from "./layout/TwoColumnLayout";
@@ -34,21 +34,26 @@ const ExperimentInput = React.memo(({
     versions: string[],
     runExperiment: (experiment: Experiment) => void,
 }) => {
+    const [version, setVersion] = useState<string | undefined>();
+    const [prompt, setPrompt] = useState<string | undefined>();
 
     const maxVersion = useMemo(() => {
         if (versions.length === 0) return undefined;
 
-        return versions
+        const maxV = versions
             .sort(semverCompare)
             .reverse()[0];
+
+        if (!version) {
+            setVersion(maxV);
+        }
+
+        return maxV;
     }, [versions]);
 
     const [temperature, setTemperature] = useState(0.2);
     const [tokenLimit, setTokenLimit] = useState(100);
 
-
-    const [prompt, setPrompt] = useState<string | undefined>();
-    const [version, setVersion] = useState<string | undefined>(maxVersion);
     const effectiveVersion = useMemo(() => version || maxVersion, [version, maxVersion]);
 
     const isValidExperimentConfig = useMemo(() => {
@@ -58,21 +63,28 @@ const ExperimentInput = React.memo(({
     const dropdownItems = useMemo(() => versions.map(v => ({ id: v, value: v })), [versions]);
 
     return (
-        <>
+        <Card>
             <div className="flex flex-col w-full gap-4">
+                <div>
+                    <h2 className=" font-semibold text-xl">Run an experiment</h2>
+                    <p className=" text-gray-400/80">
+                        Run, iterate, and refine prompts before using the model in production.
+                        If generation is slow, try adding more resources to your server.
+                    </p>
+                </div>
 
-                <div className="flex flex-row w-full gap-4 justify-start">
-                    <h3 className=" font-semibold leading-none">Prompt</h3>
+                <div className="flex flex-col w-full gap-2">
+                    <h3 className=" font-semibold  ">Prompt</h3>
                     <textarea
-                        className="ml-auto w-[80%] bg-dark-200 focus:border-primary-100 focus:ring-0 focus:shadow-none rounded-sm h-40 text-gray-400"
+                        className=" bg-dark-200 focus:border-primary-100 focus:ring-0 focus:shadow-none rounded-sm h-56 text-gray-400"
                         value={prompt}
                         placeholder="Enter prompt..."
                         onChange={(evt) => setPrompt(evt.target.value)} />
                 </div>
 
-                <div className="flex flex-row w-full gap-4 justify-start">
+                <div className="flex flex-row w-full gap-4 justify-start pt-2">
                     <h3 className=" flex-grow font-semibold leading-none">Version</h3>
-                    <div className=" items-baseline w-[80%]">
+                    <div className=" items-baseline w-[70%]">
                         <Dropdown
                             buttonText="Model Version"
                             items={dropdownItems}
@@ -85,7 +97,7 @@ const ExperimentInput = React.memo(({
                 <div className="flex flex-row w-full gap-4 justify-start">
                     <h3 className=" font-semibold leading-none">Temperature</h3>
                     <input
-                        className="ml-auto w-[80%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
+                        className="ml-auto w-[70%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
                         type="number"
                         step={0.1}
                         min={0.0}
@@ -96,7 +108,7 @@ const ExperimentInput = React.memo(({
                 <div className="flex flex-row w-full gap-4 justify-start">
                     <h3 className=" font-semibold leading-none">Token Limit</h3>
                     <input
-                        className="ml-auto w-[80%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
+                        className="ml-auto w-[70%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
                         type="number"
                         value={tokenLimit}
                         onChange={(evt) => setTokenLimit(evt.target.valueAsNumber)} />
@@ -117,7 +129,7 @@ const ExperimentInput = React.memo(({
                     </button>
                 </div>
             </div>
-        </>
+        </Card>
     )
 })
 
@@ -213,16 +225,14 @@ export default function InferenceExploration({
             </OneColumnLayout>
             <TwoColumnLayout type="equal">
                 <Column>
-                    <Widget title="Run Experiment">
-                        <ExperimentInput
-                            model={model}
-                            versions={versions}
-                            runExperiment={(experiment) => {
-                                dispatch(startActiveExperiment({
-                                    ...experiment,
-                                }))
-                            }} />
-                    </Widget>
+                    <ExperimentInput
+                        model={model}
+                        versions={versions}
+                        runExperiment={(experiment) => {
+                            dispatch(startActiveExperiment({
+                                ...experiment,
+                            }))
+                        }} />
                 </Column>
                 <Column>
                     {experiments.length == 0 ? (

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -215,9 +215,9 @@ export default function InferenceExploration({
         <>
             <OneColumnLayout>
                 <Callout>
-                    <h3 className=" text-lg font-semibold text-dark-500 leading-none ">Model Experiments</h3>
+                    <h3 className=" text-lg font-semibold text-dark-500 leading-none ">Compleation Experiments</h3>
                     <p className=" text-dark-500 leading-tight mt-2 ">
-                        This allows you to run experiments with models that are deployed to the server.
+                        This space allows you to run experiments with models that are deployed to the server.
                         Use this space to explore what is possible and refine your understanding of the boundaries of your model.
                         Experiments do not persist beyond your current session.
                     </p>

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useMemo, useState } from "react"
+import React from "react";
+
+import { isValidSemVer, semverCompare } from "../utils/semver";
+import { createDefaultClient } from "../api/services/completion";
+import { useGetModelsQuery } from "../api/services/v1";
+
+import { Icon } from "@blueprintjs/core";
+
+import Widget from "./core/Widget";
+import Dropdown from "./core/Dropdown";
+import Column from "./layout/Column";
+import TwoColumnLayout from "./layout/TwoColumnLayout";
+import Callout from "./core/Callout";
+import Pill from "./core/Pill";
+import OneColumnLayout from "./layout/OneColumnLayout";
+
+interface Experiment {
+    id: number;
+    model: string;
+    version: string;
+    temperature: number;
+    tokenLimit: number;
+    prompt: string;
+    cancel?: () => void;
+}
+
+const ExperimentInput = React.memo(({
+    model,
+    versions,
+    runExperiment,
+}: {
+    model: string,
+    versions: string[],
+    runExperiment: (experiment: Experiment) => void,
+}) => {
+
+    const maxVersion = useMemo(() => {
+        if (versions.length === 0) return undefined;
+
+        return versions
+            .sort(semverCompare)
+            .reverse()[0];
+    }, [versions]);
+
+    const [temperature, setTemperature] = useState(0.2);
+    const [tokenLimit, setTokenLimit] = useState(100);
+
+
+    const [prompt, setPrompt] = useState<string | undefined>();
+    const [version, setVersion] = useState<string | undefined>(maxVersion);
+    const effectiveVersion = useMemo(() => version || maxVersion, [version, maxVersion]);
+
+    const isValidExperimentConfig = useMemo(() => {
+        return effectiveVersion != null && isValidSemVer(effectiveVersion) && prompt;
+    }, [prompt, effectiveVersion]);
+
+    const dropdownItems = useMemo(() => versions.map(v => ({ id: v, value: v })), [versions]);
+
+    return (
+        <>
+            <div className="flex flex-col w-full gap-4">
+
+                <div className="flex flex-row w-full gap-4 justify-start">
+                    <h3 className=" font-semibold leading-none">Prompt</h3>
+                    <textarea
+                        className="ml-auto w-[80%] bg-dark-200 focus:border-primary-100 focus:ring-0 focus:shadow-none rounded-sm h-40 text-gray-400"
+                        value={prompt}
+                        placeholder="Enter prompt..."
+                        onChange={(evt) => setPrompt(evt.target.value)} />
+                </div>
+
+                <div className="flex flex-row w-full gap-4 justify-start">
+                    <h3 className=" flex-grow font-semibold leading-none">Version</h3>
+                    <div className=" items-baseline w-[80%]">
+                        <Dropdown
+                            buttonText="Model Version"
+                            items={dropdownItems}
+                            default={maxVersion}
+                            onSelectionChange={(select: string) => setVersion(select)}
+                        />
+                    </div>
+                </div>
+
+                <div className="flex flex-row w-full gap-4 justify-start">
+                    <h3 className=" font-semibold leading-none">Temperature</h3>
+                    <input
+                        className="ml-auto w-[80%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
+                        type="number"
+                        step={0.1}
+                        min={0.0}
+                        value={temperature}
+                        onChange={(evt) => setTemperature(evt.target.valueAsNumber)} />
+                </div>
+
+                <div className="flex flex-row w-full gap-4 justify-start">
+                    <h3 className=" font-semibold leading-none">Token Limit</h3>
+                    <input
+                        className="ml-auto w-[80%] focus:border-primary-100 focus:ring-0 focus:shadow-none rounded bg-dark-200 text-gray-400"
+                        type="number"
+                        value={tokenLimit}
+                        onChange={(evt) => setTokenLimit(evt.target.valueAsNumber)} />
+                </div>
+
+                <div className="flex flex-row w-full gap-4 justify-start">
+                    <button className="px-3 py-1.5 bg-primary-100 rounded hover:bg-primary-500 ml-auto disabled:opacity-25 disabled:bg-gray-400" onClick={() => {
+                        runExperiment({
+                            id: Math.random(), // TODO(aduffy): Do better.
+                            model: model,
+                            version: version!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                            temperature: temperature,
+                            tokenLimit: tokenLimit,
+                            prompt: prompt!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                        });
+                    }} disabled={!isValidExperimentConfig}>
+                        <p className=" text-dark-300 font-semibold ">Run Inference</p>
+                    </button>
+                </div>
+            </div>
+        </>
+    )
+})
+
+const ExperimentView = React.memo((
+    {
+        experiment,
+        isRunning,
+        output
+    }: {
+        experiment: Experiment,
+        isRunning: boolean,
+        output: string
+    }) => {
+
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    return (
+        <div className={`rounded p-3 outline ${isRunning ? "outline-dark-500" : "outline-primary-400/80"} `}>
+            <div className="flex flex-row w-full items-center gap-2">
+                <p className=" font-semibold text-lg "> Experiment Prompt </p>
+                <div className=" ml-auto hover:bg-gray-300/40 p-2 rounded mb-auto" onClick={() => setIsExpanded(!isExpanded)}>
+                    {isExpanded ? (<Icon icon="collapse-all" size={14} color="#F6F7F9" />) :
+                        (<Icon icon="expand-all" size={14} color="#F6F7F9" />)
+                    }
+                </div>
+            </div>
+            <div className="flex flex-row w-full items-center">
+                <p className="leading-snug">{experiment.prompt}</p>
+            </div>
+
+            {isExpanded && (
+                <>
+                    <div className={`my-4 border-t border-gray-400/70 w-1/2 mx-auto `} />
+                    <div className="flex flex-row w-full items-center pb-2 gap-2">
+                        <p className="font-semibold">Model Output</p>
+                        <Pill icon="history" text={experiment.version} color="purple" />
+                        <Pill icon="temperature" text={`${experiment.temperature}`} color="purple" />
+                        <Pill icon="lengthen-text" text={`${experiment.tokenLimit}`} color="purple" />
+                    </div>
+                    <div className="flex flex-row w-full items-center">
+                        <p className="leading-snug font-mono text-sm whitespace-pre-line">
+                            {output}
+                        </p>
+                    </div>
+                </>
+            )}
+        </div>
+    )
+})
+
+const Experiment = React.memo((
+    {
+        experiment
+    }: {
+        experiment: Experiment
+    }) => {
+    const [tokens, setTokens] = useState("");
+    const [completed, setCompleted] = useState(false);
+
+    useEffect(() => {
+        const client = createDefaultClient(experiment.model, experiment.version);
+
+        async function startWebSocket() {
+            await client.connect();
+            client.completeAsync(
+                {
+                    prompt: experiment.prompt,
+                    temperature: experiment.temperature,
+                    tokens: experiment.tokenLimit,
+                },
+                (token) => setTokens(prev => prev + token),
+                () => {
+                    setCompleted(true);
+                },
+            )
+        }
+
+        // Kick off async task.
+        startWebSocket();
+
+        return () => {
+            client.disconnect();
+        }
+    }, [experiment.model, experiment.version, experiment.prompt, experiment.temperature, experiment.tokenLimit]);
+
+    const isRunning = useMemo(() => completed ? false : true, [completed]);
+
+    return (
+        <ExperimentView
+            key={experiment.id}
+            output={tokens}
+            experiment={experiment}
+            isRunning={isRunning} />
+    )
+})
+
+export default function InferenceExploration({
+    model,
+}: {
+    model: string,
+}) {
+    const [experiments, setExperiments] = useState<Experiment[]>([]);
+    const { data: allModels } = useGetModelsQuery();
+
+    const versions = useMemo(
+        () =>
+            allModels
+                ? allModels.models.filter(m => m.name === model).flatMap(m => m.versions).map(v => v.version)
+                : [], [allModels, model])
+
+    return (
+        <>
+            <OneColumnLayout>
+                <Callout>
+                    <h3 className=" text-lg font-semibold text-dark-500 leading-none ">Run an Experiment</h3>
+                    <p className=" text-dark-500 leading-tight mt-2 ">
+                        Run, iterate, and refine your prompts before using the model in production.
+                        All prompts are run live against this WebServer.
+                        If responses are slow, try adding more resources to your server.
+                    </p>
+                </Callout>
+            </OneColumnLayout>
+            <TwoColumnLayout type="equal">
+                <Column>
+                    <Widget title="Run Experiment">
+                        <ExperimentInput
+                            model={model}
+                            versions={versions}
+                            runExperiment={(experiment) => {
+                                setExperiments((oldExperiments) => [experiment, ...oldExperiments])
+                            }} />
+                    </Widget>
+                </Column>
+                <Column>
+                    {experiments.length == 0 ? (
+                        <div className="flex flex-col h-full w-3/4 mx-auto items-center justify-center">
+                            <div className="rounded outline outline-gray-400 p-8 justify-center">
+                                <h3 className=" text-lg text-center font-semibold">Start an Experiment</h3>
+                                <p className="text-center text-gray-400/60">
+                                    Results of your experiments will appear here.
+                                    Experiment currently do not persist if you reload the page.
+                                </p>
+                            </div>
+                        </div>
+                    ) : (
+                        <>
+                            {experiments.map(experiment => (
+                                <div className="mb-5">
+                                    <Experiment experiment={experiment} />
+                                </div>
+                            ))}
+                        </>
+                    )}
+                </Column>
+            </TwoColumnLayout>
+        </>
+    )
+}

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -215,11 +215,11 @@ export default function InferenceExploration({
         <>
             <OneColumnLayout>
                 <Callout>
-                    <h3 className=" text-lg font-semibold text-dark-500 leading-none ">Run an Experiment</h3>
+                    <h3 className=" text-lg font-semibold text-dark-500 leading-none ">Model Experiments</h3>
                     <p className=" text-dark-500 leading-tight mt-2 ">
-                        Run, iterate, and refine your prompts before using the model in production.
-                        All prompts are run live against this WebServer.
-                        If responses are slow, try adding more resources to your server.
+                        This allows you to run experiments with models that are deployed to the server.
+                        Use this space to explore what is possible and refine your understanding of the boundaries of your model.
+                        Experiments do not persist beyond your current session.
                     </p>
                 </Callout>
             </OneColumnLayout>

--- a/frontend/src/components/InferenceExploration.tsx
+++ b/frontend/src/components/InferenceExploration.tsx
@@ -37,6 +37,12 @@ const ExperimentInput = React.memo(({
     const [version, setVersion] = useState<string | undefined>();
     const [prompt, setPrompt] = useState<string | undefined>();
 
+    const setVersionFromMemo = (ver: string) => {
+        if (!version) {
+            setVersion(ver);
+        }
+    }
+
     const maxVersion = useMemo(() => {
         if (versions.length === 0) return undefined;
 
@@ -44,9 +50,7 @@ const ExperimentInput = React.memo(({
             .sort(semverCompare)
             .reverse()[0];
 
-        if (!version) {
-            setVersion(maxV);
-        }
+        setVersionFromMemo(maxV);
 
         return maxV;
     }, [versions]);

--- a/frontend/src/components/core/Card.tsx
+++ b/frontend/src/components/core/Card.tsx
@@ -7,7 +7,7 @@ export default function Card(
     }
 ) {
     return (
-        <div className=" w-full h-full p-4 rounded bg-dark-500/80 ">
+        <div className=" w-full p-4 rounded bg-dark-500/80 ">
             {children}
         </div>
     )

--- a/frontend/src/components/core/Card.tsx
+++ b/frontend/src/components/core/Card.tsx
@@ -1,32 +1,14 @@
-import { TrashIcon } from "@heroicons/react/20/solid";
-
-export default function Card({
-    title,
-    version,
-    guid,
-    deleteHandler
-}:{
-    title: string,
-    version: string,
-    guid: string,
-    deleteHandler: (arg: string) => void
-}) {
-  return (
-    <div className=" container outline rounded-md p-4 ">
-        <div className="flex flex-col h-20 gap-2">
-            <div className="flex flex-row items-center leading-tight">
-                <p className=" text-lg font-semibold ">{title}</p>
-                <TrashIcon 
-                    onClick={() => deleteHandler(guid)}
-                    className="cursor-pointer h-5 w-5 ml-auto hover:text-red-500 text-slate-500"/>
-            </div>
-            <div className="flex flex-row">
-                <p className=" font-mono text-sm"><span className=" font-sans font-semibold ">Version: </span>{version}</p>
-            </div>
-            <div className="flex flex-row">
-                <p className=" font-mono text-sm"><span className=" font-sans font-semibold ">Type: </span>Completion</p>
-            </div>
+export default function Card(
+    {
+        children
+    }:
+    {
+        children: React.ReactNode | React.ReactNode[],
+    }
+) {
+    return (
+        <div className=" w-full h-full p-4 rounded bg-dark-500/80 ">
+            {children}
         </div>
-    </div>
-  );
+    )
 }

--- a/frontend/src/components/core/Pill.tsx
+++ b/frontend/src/components/core/Pill.tsx
@@ -1,21 +1,27 @@
+import { Icon } from "@blueprintjs/core"
+import {BlueprintIcons_16Id} from "@blueprintjs/icons/src/generated-icons/16px/blueprint-icons-16.ts"
+
 export default function Pill(
     {
         text,
         color,
+        icon
     }: {
         text: string,
         color?: "blue" | "purple" | "primary",
+        icon?: BlueprintIcons_16Id
     }) {
 
     const colors = {
-        blue: "bg-blue-500",
+        blue: "bg-blue-400",
         purple: "bg-purple-400",
         primary: "bg-primary-400",
     }
 
     return (
-        <div className={`${colors[color || "primary"]} px-3 py-1.5 rounded-3xl`}>
-            <p className=" text-dark-200 font-bold text-sm">{text}</p>
+        <div className={`flex flex-row gap-1 items-center ${colors[color || "primary"]} px-2 py-1 rounded-3xl`}>
+            {icon && <Icon icon={icon} size={14} color={"#252A31"} />}
+            <p className=" text-dark-200 font-bold text-xs">{text}</p>
         </div>
     )
 }

--- a/frontend/src/components/core/Section.tsx
+++ b/frontend/src/components/core/Section.tsx
@@ -1,4 +1,3 @@
-
 export default function Section({
     children
 } : {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,0 @@
-export default function Header() {
-    return (
-        <>
-        </>
-    )
-}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,6 @@
+export default function Header() {
+    return (
+        <>
+        </>
+    )
+}

--- a/frontend/src/components/layout/Page.tsx
+++ b/frontend/src/components/layout/Page.tsx
@@ -16,7 +16,7 @@ export default function Page(
                     </div>
                 </div>
             )}
-            <div className=" w-10/12 h-full pt-5 mx-auto ">
+            <div className=" w-10/12 pt-5 mx-auto ">
                 {children}
             </div>
         </div>

--- a/frontend/src/components/layout/Page.tsx
+++ b/frontend/src/components/layout/Page.tsx
@@ -1,13 +1,24 @@
 export default function Page(
     {
-        children
-    } : {
+        children,
+        header
+    }: {
         children: React.ReactNode | React.ReactNode[],
+        header?: React.ReactNode
     }
 ) {
     return (
-        <div className=" w-10/12 h-full pt-5 mx-auto ">
-            {children}
+        <div className="h-full">
+            {header && (
+                <div className=" w-full mx-auto bg-dark-200">
+                    <div className=" w-10/12 h-full pt-5 mx-auto ">
+                        {header}
+                    </div>
+                </div>
+            )}
+            <div className=" w-10/12 h-full pt-5 mx-auto ">
+                {children}
+            </div>
         </div>
     )
 }

--- a/frontend/src/pages/Model.tsx
+++ b/frontend/src/pages/Model.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Outlet, useParams, useNavigate } from "react-router-dom";
+import { Outlet, useParams, useNavigate, useLocation } from "react-router-dom";
 import { BlueprintIcons_16Id } from "@blueprintjs/icons/src/generated-icons/16px/blueprint-icons-16.ts"
 import Page from "../components/layout/Page";
 import { Icon } from "@blueprintjs/core";
@@ -7,11 +7,11 @@ import { Icon } from "@blueprintjs/core";
 function ModelHeader() {
     const { name } = useParams<"name">();
     const navigate = useNavigate();
-    const [ currentTab, setCurrentTab ] = useState("overview");
+    const [ currentTab, setCurrentTab ] = useState(useLocation().pathname);
 
-    const tabClick = (tabId: string, tabRoute: string) => {
-        if(currentTab !== tabId) {
-            setCurrentTab(tabId)
+    const tabClick = (tabRoute: string) => {
+        if(currentTab !== tabRoute) {
+            setCurrentTab(tabRoute)
             navigate(tabRoute)
         }
     }
@@ -35,9 +35,9 @@ function ModelHeader() {
         <div className=" flex flex-col justify-between">
 
             <h2 className=" font-semibold text-xl ">{name}</h2>
-            <div className="flex flex-row pt-6 gap-4">
+            <div className="flex flex-row pt-10 gap-4">
                 {tabs.map(tab => (
-                    <div key={tab.id} onClick={() => tabClick(tab.id, tab.route)} className={` ${currentTab === tab.id ? "border-b-2 border-primary-600" : ""} flex flex-row gap-2 cursor-pointer pb-2 pr-1`}>
+                    <div key={tab.id} onClick={() => tabClick(tab.route)} className={` ${currentTab === tab.route ? "border-b-2 border-primary-600" : ""} flex flex-row gap-2 cursor-pointer pb-2 pr-1`}>
                         <div className=" ">
                             <Icon icon={tab.icon as BlueprintIcons_16Id} size={16} color={"#E5E8EB"} />
                         </div>

--- a/frontend/src/pages/Model.tsx
+++ b/frontend/src/pages/Model.tsx
@@ -1,133 +1,58 @@
-import { useMemo, useState } from "react";
-import { useGetDescriptionQuery, useGetModelsQuery, useUpdateDescriptionMutation, isHuggingFaceSource } from "../api/services/v1";
-
-import Pill from "../components/core/Pill";
-import InferenceExploration from "../components/InferenceExploration";
-import { useParams } from "react-router-dom";
-import EditableCode from "../components/EditableCode";
-import Widget from "../components/core/Widget";
-
+import { useState } from "react";
+import { Outlet, useParams, useNavigate } from "react-router-dom";
+import { BlueprintIcons_16Id } from "@blueprintjs/icons/src/generated-icons/16px/blueprint-icons-16.ts"
 import Page from "../components/layout/Page";
-import OneColumnLayout from "../components/layout/OneColumnLayout";
-import TwoColumnLayout from "../components/layout/TwoColumnLayout";
-import Column from "../components/layout/Column";
+import { Icon } from "@blueprintjs/core";
 
-export default function Model() {
+function ModelHeader() {
     const { name } = useParams<"name">();
-    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-    const modelName = name!;
+    const navigate = useNavigate();
+    const [ currentTab, setCurrentTab ] = useState("overview");
 
-    const [selectedTab, isSelectedTab] = useState("overview")
-
-    const { registeredModel } = useGetModelsQuery(undefined, {
-        selectFromResult: ({ data }) => ({ registeredModel: data?.models.find(m => m.name === modelName) })
-    })
-
-    const source = useMemo(() => {
-        if (registeredModel === undefined) {
-            return undefined;
+    const tabClick = (tabId: string, tabRoute: string) => {
+        if(currentTab !== tabId) {
+            setCurrentTab(tabId)
+            navigate(tabRoute)
         }
+    }
 
-        const latest = registeredModel.versions[registeredModel.versions.length - 1];
-        const importSource = latest.import_metadata.source
-        if (isHuggingFaceSource(importSource)) {
-            return {
-                link: `https://huggingface.co/${importSource.source.repo}/blob/main/${importSource.source.file}`,
-                popover: importSource.source.repo,
-                importTime: latest.import_metadata.imported_at,
-                sourceDisplayName: "HuggingFace",
-            }
-        } else {
-            return {
-                link: undefined,
-                popover: importSource.source.path,
-                importTime: latest.import_metadata.imported_at,
-                sourceDisplayName: "File Upload",
-            }
+    const tabs = [
+        {
+            id: "overview",
+            display: "Overview",
+            icon: "git-repo",
+            route: `/model/${name}`
+        },
+        {
+            id: "experiments",
+            display: "Experiments",
+            icon: "lab-test",
+            route: `/model/${name}/experiments`
         }
-    }, [registeredModel]);
-
-    const { data: description } = useGetDescriptionQuery(modelName);
-    const [updateDescriptionAction] = useUpdateDescriptionMutation();
-    const markdown = `# ${modelName}`;
+    ]
 
     return (
-        <Page>
-            <OneColumnLayout>
-                <Column>
-                    <div className=" bg-dark-200 p-4 rounded">
-                        <div className="flex flex-row h-full gap-4 justify-items-start pb-5">
-                            <h1 className=" leading-none text-3xl font-semibold">{modelName}</h1>
-                        </div>
-                        <div className="flex flex-row h-full gap-4 justify-items-start">
-                            <div onClick={() => isSelectedTab("overview")}>
-                                <h3 className={` cursor-pointer leading-none text-md font-semibold ${selectedTab == "overview" ? " text-primary-400" : " "}`}>Overview</h3>
-                            </div>
-                            <div onClick={() => isSelectedTab("experiments")}>
-                                <h3 className={` cursor-pointer leading-none text-md font-semibold ${selectedTab == "experiments" ? " text-primary-400" : " "}`}>Experiments</h3>
-                            </div>
-                        </div>
-                    </div>
-                </Column>
-            </OneColumnLayout>
-            {selectedTab == "overview" && (
-                <TwoColumnLayout type="left">
-                    <Column>
-                        <EditableCode
-                            initialCode={markdown}
-                            code={description}
-                            langage="markdown"
-                            setCode={
-                                (desc) => {
-                                    updateDescriptionAction({
-                                        modelName,
-                                        description: desc,
-                                    });
-                                }
-                            }
-                        />
+        <div className=" flex flex-col justify-between">
 
-                    </Column>
-                    <Column>
-                        <Widget title="About">{
-                            registeredModel &&
-                            (<div className="overflow-y-auto [&::-webkit-scrollbar]:hidden">
-                                <div className="flex flex-row items-center gap-4 pb-4" >
-                                    <p className=" w-1/3 font-semibol ">Model Type</p>
-                                    <Pill text={registeredModel.model_type}></Pill>
-                                </div>
-                                <div className="flex flex-row items-center gap-4 pb-4" >
-                                    <p className=" w-1/3 font-semibold">Source</p>
-                                    <a href={source?.link ?? "about:blank"} target="_blank">
-                                        <Pill text={source?.sourceDisplayName ?? ""}></Pill>
-                                    </a>
-                                </div>
-                                <div className="flex flex-row items-center gap-4 pb-4" >
-                                    <p className=" w-1/3 font-semibold">Lineage</p>
-                                    <Pill text="LLaMa"></Pill>
-                                </div>
-                                <div className="flex flex-row items-center gap-4 pb-4" >
-                                    <p className=" w-1/3 font-semibold">Format</p>
-                                    <Pill text={registeredModel.runtime}></Pill>
-                                </div>
-                            </div>)
-                        }
-                        </Widget>
-                        <Widget title="History">
-                            <div className="overflow-y-auto [&::-webkit-scrollbar]:hidden">
-                                <p>Version history for the model</p>
-                            </div>
-                        </Widget>
-                    </Column>
-                </TwoColumnLayout>
-            )}
-            {selectedTab == "experiments" && (
-                <OneColumnLayout>
-                    <Column>
-                        <InferenceExploration model={modelName} />
-                    </Column>
-                </OneColumnLayout>
-            )}
+            <h2 className=" font-semibold text-xl ">{name}</h2>
+            <div className="flex flex-row pt-6 gap-4">
+                {tabs.map(tab => (
+                    <div key={tab.id} onClick={() => tabClick(tab.id, tab.route)} className={` ${currentTab === tab.id ? "border-b-2 border-primary-600" : ""} flex flex-row gap-2 cursor-pointer pb-2 pr-1`}>
+                        <div className=" ">
+                            <Icon icon={tab.icon as BlueprintIcons_16Id} size={16} color={"#E5E8EB"} />
+                        </div>
+                        <p className=" font-semibold leading-none">{tab.display}</p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export default function Model() {
+    return (
+        <Page header={<ModelHeader />}>
+            <Outlet />
         </Page>
     )
 }

--- a/frontend/src/pages/Model.tsx
+++ b/frontend/src/pages/Model.tsx
@@ -6,7 +6,6 @@ import InferenceExploration from "../components/InferenceExploration";
 import { useParams } from "react-router-dom";
 import EditableCode from "../components/EditableCode";
 import Widget from "../components/core/Widget";
-import InferenceRunner from "../components/InferenceRunner";
 
 import Page from "../components/layout/Page";
 import OneColumnLayout from "../components/layout/OneColumnLayout";
@@ -62,10 +61,10 @@ export default function Model() {
                         </div>
                         <div className="flex flex-row h-full gap-4 justify-items-start">
                             <div onClick={() => isSelectedTab("overview")}>
-                                <h3 className={ ` cursor-pointer leading-none text-md font-semibold ${selectedTab == "overview" ? " text-primary-400" : " "}` }>Overview</h3>
+                                <h3 className={` cursor-pointer leading-none text-md font-semibold ${selectedTab == "overview" ? " text-primary-400" : " "}`}>Overview</h3>
                             </div>
                             <div onClick={() => isSelectedTab("experiments")}>
-                                <h3 className={ ` cursor-pointer leading-none text-md font-semibold ${selectedTab == "experiments" ? " text-primary-400" : " "}` }>Experiments</h3>
+                                <h3 className={` cursor-pointer leading-none text-md font-semibold ${selectedTab == "experiments" ? " text-primary-400" : " "}`}>Experiments</h3>
                             </div>
                         </div>
                     </div>
@@ -125,7 +124,7 @@ export default function Model() {
             {selectedTab == "experiments" && (
                 <OneColumnLayout>
                     <Column>
-                        <InferenceExploration model={modelName}/>
+                        <InferenceExploration model={modelName} />
                     </Column>
                 </OneColumnLayout>
             )}

--- a/frontend/src/pages/Model/Experiments.tsx
+++ b/frontend/src/pages/Model/Experiments.tsx
@@ -1,0 +1,19 @@
+import InferenceExploration from "../../components/InferenceExploration"
+import OneColumnLayout from "../../components/layout/OneColumnLayout"
+import Column from "../../components/layout/Column"
+
+import { useParams } from "react-router-dom";
+
+export default function Experiments() {
+    const { name } = useParams<"name">();
+    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+    const modelName = name!;
+
+    return (
+        <OneColumnLayout>
+            <Column>
+                <InferenceExploration model={modelName} />
+            </Column>
+        </OneColumnLayout>
+    )
+}

--- a/frontend/src/pages/Model/Overview.tsx
+++ b/frontend/src/pages/Model/Overview.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from "react";
+import { useGetDescriptionQuery, useGetModelsQuery, useUpdateDescriptionMutation, isHuggingFaceSource } from "../../api/services/v1";
+
+import Pill from "../../components/core/Pill";
+import { useParams } from "react-router-dom";
+import EditableCode from "../../components/EditableCode";
+import Widget from "../../components/core/Widget";
+
+import TwoColumnLayout from "../../components/layout/TwoColumnLayout";
+import Column from "../../components/layout/Column";
+
+export default function Overview() {
+    const { name } = useParams<"name">();
+    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
+    const modelName = name!;
+
+    const { registeredModel } = useGetModelsQuery(undefined, {
+        selectFromResult: ({ data }) => ({ registeredModel: data?.models.find(m => m.name === modelName) })
+    })
+
+    const source = useMemo(() => {
+        if (registeredModel === undefined) {
+            return undefined;
+        }
+
+        const latest = registeredModel.versions[registeredModel.versions.length - 1];
+        const importSource = latest.import_metadata.source
+        if (isHuggingFaceSource(importSource)) {
+            return {
+                link: `https://huggingface.co/${importSource.source.repo}/blob/main/${importSource.source.file}`,
+                popover: importSource.source.repo,
+                importTime: latest.import_metadata.imported_at,
+                sourceDisplayName: "HuggingFace",
+            }
+        } else {
+            return {
+                link: undefined,
+                popover: importSource.source.path,
+                importTime: latest.import_metadata.imported_at,
+                sourceDisplayName: "File Upload",
+            }
+        }
+    }, [registeredModel]);
+
+    const { data: description } = useGetDescriptionQuery(modelName);
+    const [updateDescriptionAction] = useUpdateDescriptionMutation();
+    const markdown = `# ${modelName}`;
+
+    return (
+        <TwoColumnLayout type="left">
+            <Column>
+                <EditableCode
+                    initialCode={markdown}
+                    code={description}
+                    langage="markdown"
+                    setCode={
+                        (desc) => {
+                            updateDescriptionAction({
+                                modelName,
+                                description: desc,
+                            });
+                        }
+                    }
+                />
+
+            </Column>
+            <Column>
+                <Widget title="About">{
+                    registeredModel &&
+                    (<div className="overflow-y-auto [&::-webkit-scrollbar]:hidden">
+                        <div className="flex flex-row items-center gap-4 pb-4" >
+                            <p className=" w-1/3 font-semibol ">Model Type</p>
+                            <Pill text={registeredModel.model_type}></Pill>
+                        </div>
+                        <div className="flex flex-row items-center gap-4 pb-4" >
+                            <p className=" w-1/3 font-semibold">Source</p>
+                            <a href={source?.link ?? "about:blank"} target="_blank">
+                                <Pill text={source?.sourceDisplayName ?? ""}></Pill>
+                            </a>
+                        </div>
+                        <div className="flex flex-row items-center gap-4 pb-4" >
+                            <p className=" w-1/3 font-semibold">Lineage</p>
+                            <Pill text="LLaMa"></Pill>
+                        </div>
+                        <div className="flex flex-row items-center gap-4 pb-4" >
+                            <p className=" w-1/3 font-semibold">Format</p>
+                            <Pill text={registeredModel.runtime}></Pill>
+                        </div>
+                    </div>)
+                }
+                </Widget>
+                <Widget title="History">
+                    <div className="overflow-y-auto [&::-webkit-scrollbar]:hidden">
+                        <p>Version history for the model</p>
+                    </div>
+                </Widget>
+            </Column>
+        </TwoColumnLayout>
+    )
+}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -12,7 +12,7 @@ export default function Workspace() {
     return (
         <div className='bg-dark-300 '>
             <header className=' sticky top-0 z-50'>
-                <div className='flex flex-row h-16 p-4 items-center bg-dark-200 gap-2'>
+                <div className='flex flex-row h-16 p-4 items-center bg-dark-100 gap-2'>
                     <Link to="/">
                         <p className="text-lg font-semibold">Model Server</p>
                     </Link>

--- a/frontend/src/state/appSlice.ts
+++ b/frontend/src/state/appSlice.ts
@@ -1,29 +1,93 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { RegisteredModel } from "../api";
-export interface AppState {
-    // All models from the server that the user has access to
-    models: Array<RegisteredModel>;
+import { createListenerMiddleware, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createDefaultClient } from "../api/services/completion";
 
-    // Actively being viewed model
-    activeModel: [string, string] | undefined;
+
+export type ExperimentId = number;
+export interface Experiment {
+    id: ExperimentId;
+    model: string;
+    version: string;
+    temperature: number;
+    tokenLimit: number;
+    prompt: string;
+}
+
+export interface ExperimentState {
+    experiment: Experiment;
+    output: string;
+    active: boolean;
+}
+
+export interface AppState {
+    // Set of visible experiments
+    experiments: ExperimentState[],
 }
 
 const initialState: AppState = {
-    models: [],
-    activeModel: undefined,
+    experiments: [],
 }
 
 export const appSlice = createSlice({
     name: "app",
     initialState,
     reducers: {
-        loadModels: (state, action: PayloadAction<Array<RegisteredModel>>) => {
-            state.models.push(...action.payload);
+        // Ad to specific experiment output token
+        startActiveExperiment: (state, action: PayloadAction<Experiment>) => {
+            state.experiments.unshift({
+                experiment: action.payload,
+                active: true,
+                output: "",
+            });
         },
-        setActiveModel: (state, action: PayloadAction<[string, string] | undefined>) => {
-            state.activeModel = action.payload;
+        addOutputToken: (state, action: PayloadAction<{ id: ExperimentId, token: string }>) => {
+            const { id, token } = action.payload;
+            const experiment = state.experiments.find(ex => ex.experiment.id == id);
+            // Prevent taking new output tokens after experiment is no longer active. This probably shoudln't happen anyway...
+            if (experiment === undefined || !experiment.active) {
+                return;
+            }
+            experiment.output += token;
+        },
+        completeExperiment: (state, action: PayloadAction<ExperimentId>) => {
+            const experiment = state.experiments.find(ex => ex.experiment.id === action.payload);
+            if (experiment === undefined || !experiment.active) {
+                return;
+            }
+
+            experiment.active = false;
         },
     },
 });
 
-export const { loadModels, setActiveModel } = appSlice.actions;
+export const { startActiveExperiment, addOutputToken, completeExperiment } = appSlice.actions;
+
+// TODO(aduffy): move to own file?
+export const wsMiddleware = createListenerMiddleware();
+wsMiddleware.startListening({
+    actionCreator: startActiveExperiment,
+    effect: async (action, listenerApi) => {
+        const experiment = action.payload;
+        const { id, model, version } = action.payload;
+        const client = createDefaultClient(model, version);
+
+        async function startWebSocket() {
+            await client.connect();
+            await new Promise((resolve) => {
+                client.completeAsync(
+                    {
+                        prompt: experiment.prompt,
+                        temperature: experiment.temperature,
+                        tokens: experiment.tokenLimit,
+                    },
+                    (token) => listenerApi.dispatch(addOutputToken({ id, token })),
+                    () => {
+                        listenerApi.dispatch(completeExperiment(id));
+                        resolve(undefined);
+                    },
+                )
+            });
+        }
+
+        await startWebSocket();
+    },
+});

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { v1API } from '../api/services/v1';
 import { huggingFaceServiceAPI } from '../api/services/hfService';
-import { appSlice } from "./appSlice";
+import { appSlice, wsMiddleware } from "./appSlice";
 
 export const store = configureStore({
   reducer: {
@@ -10,7 +10,7 @@ export const store = configureStore({
     app: appSlice.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(v1API.middleware, huggingFaceServiceAPI.middleware),
+    getDefaultMiddleware().concat(v1API.middleware, huggingFaceServiceAPI.middleware, wsMiddleware.middleware),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import pluginRewriteAll from 'vite-plugin-rewrite-all';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), pluginRewriteAll()],
+  appType: "spa",
   server: {
     strictPort: true,
     port: 5173,


### PR DESCRIPTION
This PR does the following:

- Updates `<Page>` to include a optional header section for more structured layouts
- Refactors the `Model` page to include a new header and splits out content to `/Pages/Model/Overview` and  `/Pages/Model/Experiments`
- Uses React Router for Tab Routing in `Model` page, which allows deep linking to a particular tab on the `Model` page
- Introduces a new `InferenceExperiment` component which replaces  `InferenceRunner`
- Updates `Pill` Components to include the ability to attach an Icon
- Moves Exploration data into Redux store
- Refactors the `<Card>` to be more useful across the UX, migrates from `Widget` to `Card` for `InferenceExperimentInput`
- Updates `Workspace` Menu bar bg color to be darker to provide better contrast with new header section
- Adds `Vite-Bundle-Visualizer` to the package.json