### PR TITLE
Experiment saving

### DIFF
--- a/modelserver/db/_core.py
+++ b/modelserver/db/_core.py
@@ -4,6 +4,8 @@ from modelserver.types.api import (
     ModelVersionInternal,
     RegisteredModel,
     RegisterModelRequest,
+    SavedExperimentIn,
+    SavedExperimentOut,
 )
 
 
@@ -62,4 +64,25 @@ class DataManager(ABC):
         Retrieve the description for a model
         :param model_name: Name of the model, e.g. "vicuna-7b"
         :return: The Markdown-formatted description for the model, or null if none is found.
+        """
+
+    @abstractmethod
+    def get_experiments(self, model_name: str) -> list[SavedExperimentOut]:
+        """
+        Returns a list of experiments, ordered ascending by their created_at date.
+        """
+
+    @abstractmethod
+    def save_experiment(
+        self, saved_experiment: SavedExperimentIn
+    ) -> SavedExperimentOut:
+        """
+        Save an experiment to a collection for the user to browse later.
+        """
+
+    @abstractmethod
+    def delete_experiment(self, experiment_id: str) -> None:
+        """
+        Delete the experiment by ID.
+        :param experiment_id: The ID of the saved experiment
         """

--- a/modelserver/db/_tables.py
+++ b/modelserver/db/_tables.py
@@ -1,6 +1,17 @@
 from typing import TypedDict
 
-from sqlalchemy import Column, DateTime, ForeignKey, MetaData, String, Table, and_
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    and_,
+)
 from sqlalchemy.dialects.sqlite import JSON
 
 """
@@ -26,33 +37,59 @@ model_table = Table(
     metadata_obj,
     Column("id", String, primary_key=True),
     Column("name", String, unique=True),
-    Column("model_type", String),
-    Column("runtime", String, primary_key=True),
-    Column("description", String),
+    Column("model_type", String, nullable=False),
+    Column("runtime", String, nullable=False),
+    Column("description", String, nullable=False),
 )
 
 model_version_table = Table(
     "model_version",
     metadata_obj,
-    Column("model_id", ForeignKey("model.id"), primary_key=True),
+    Column("model_id", String, primary_key=True),
     Column("version", String, primary_key=True),
+    ForeignKeyConstraint(["model_id"], ["model.id"]),
 )
 
 import_metadata_table = Table(
     "import_metadata",
     metadata_obj,
-    Column("model_id", ForeignKey("model_version.model_id"), primary_key=True),
-    Column("model_version", ForeignKey("model_version.version"), primary_key=True),
+    Column("model_id", String, primary_key=True),
+    Column("model_version", String, primary_key=True),
     Column("source", JSON, nullable=False),
     Column("imported_at", DateTime, nullable=False),
+    ForeignKeyConstraint(
+        ["model_id", "model_version"],
+        ["model_version.model_id", "model_version.version"],
+    ),
 )
 
 model_params_table = Table(
     "model_params",
     metadata_obj,
-    Column("model_id", ForeignKey("model_version.model_id"), primary_key=True),
-    Column("model_version", ForeignKey("model_version.version"), primary_key=True),
+    Column("model_id", String, primary_key=True),
+    Column("model_version", String, primary_key=True),
     Column("params", JSON, nullable=False),
+    ForeignKeyConstraint(
+        ["model_id", "model_version"],
+        ["model_version.model_id", "model_version.version"],
+    ),
+)
+
+saved_experiments_table = Table(
+    "saved_experiments",
+    metadata_obj,
+    Column("id", String, primary_key=True),
+    Column("model_id", String, nullable=False),
+    Column("model_version", String, nullable=False),
+    Column("temperature", Float, nullable=False),
+    Column("tokens", Integer, nullable=False),
+    Column("prompt", String, nullable=False),
+    Column("output", String, nullable=False),
+    Column("created_at", DateTime, nullable=False),
+    ForeignKeyConstraint(
+        ["model_id", "model_version"],
+        ["model_version.model_id", "model_version.version"],
+    ),
 )
 
 

--- a/modelserver/db/test_db.py
+++ b/modelserver/db/test_db.py
@@ -1,12 +1,18 @@
 from datetime import datetime
 
 import pytest
+import sqlalchemy.exc
 from fastapi import HTTPException, status
 from sqlalchemy import create_engine
 
 from modelserver.types.tasks import InProgressState, TaskState
 
-from ..types.api import RegisterModelRequest, SemVer
+from ..types.api import (
+    RegisterModelRequest,
+    SavedExperimentIn,
+    SavedExperimentOut,
+    SemVer,
+)
 from .sqlite import PersistentDataManager
 
 
@@ -16,7 +22,7 @@ def test_db() -> None:
     assert db.get_registered_models() == []
 
     # 1: model registration
-    unversioned_model_info = RegisterModelRequest.parse_obj(
+    register_request = RegisterModelRequest.parse_obj(
         {
             "model": "anewmodel",
             "version": "0.1.0",
@@ -39,15 +45,15 @@ def test_db() -> None:
         }
     )
 
-    db.register_model(unversioned_model_info)
+    db.register_model(register_request)
     assert len(db.get_registered_models()) == 1
     assert db.get_model_version_internal("anewmodel", "0.1.0") is not None
 
-    versioned_model_info = unversioned_model_info.copy(
+    register_request_versionbump = register_request.copy(
         update=dict(version=SemVer.from_str("0.2.0"))
     )
 
-    db.register_model(versioned_model_info)
+    db.register_model(register_request_versionbump)
     models = db.get_registered_models()
     assert len(db.get_registered_models()) == 1
     assert len(models[0].versions) == 2
@@ -56,7 +62,7 @@ def test_db() -> None:
 
     # Ensure duplicative model registration fails with 409 CONFLICT exception
     with pytest.raises(HTTPException) as http_ex:
-        db.register_model(versioned_model_info)
+        db.register_model(register_request_versionbump)
     assert http_ex.value.status_code == status.HTTP_409_CONFLICT
 
     # Ensure model lookups fail with 404 exception
@@ -67,6 +73,48 @@ def test_db() -> None:
     db.delete_model_version("anewmodel", "0.2.0")
 
     assert len(db.get_registered_models()) == 1
+
+    ### Renaming
+
+    # Test 1: Simple rename
+    db.set_model_name("anewmodel", "a_new_model")
+    assert db.get_registered_models()[0].name == "a_new_model"
+
+    ### Saved experiments
+
+    # Test 1: Simple model save logic
+    model = db.get_registered_models()[0]
+    experiment_in = SavedExperimentIn(
+        model_id=str(model.id),
+        model_version=SemVer.from_str("0.2.0"),
+        tokens=50,
+        temperature=0.1,
+        prompt="User: Tell a joke\nSystem:",
+        output=" Why did the chicken cross the road?",
+    )
+    db.save_experiment(experiment_in)
+    saved = db.get_experiments(model.name)[0]
+    assert saved.model_id == experiment_in.model_id
+    assert saved.model_version == experiment_in.model_version
+    assert saved.tokens == experiment_in.tokens
+    assert saved.temperature == experiment_in.temperature
+    assert saved.prompt == experiment_in.prompt
+    assert saved.output == experiment_in.output
+
+    # Test 2: Experiment should fail to save with bad model_id reference
+    experiment_bad_modelid = experiment_in.copy(update={"model_id": "nonsense"})
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        db.save_experiment(experiment_bad_modelid)
+
+    # Test 3: Experiment should fail to save with bad model version reference
+    experiment_bad_version = experiment_in.copy(
+        update={"model_version": SemVer.from_str("100.999.999")}
+    )
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        db.save_experiment(experiment_bad_version)
+    # Test 4: Delete logic
+    db.delete_experiment(saved.experiment_id)
+    assert len(db.get_experiments("anewmodel")) == 0
 
 
 def test_taskdb() -> None:

--- a/modelserver/ggml.py
+++ b/modelserver/ggml.py
@@ -220,7 +220,6 @@ class GGMLFile:
     def read_tensor_descriptors(self, fp: BufferedReader) -> List[GGMLTensorDescriptor]:
         tensor_descs: List[GGMLTensorDescriptor] = []
         while len(fp.peek(4)[:4]) == 4:
-            # import pdb; pdb.set_trace()
             n_dims = self.read_u32(fp)
             if not (n_dims == 1 or n_dims == 2):
                 raise GGMLParseError(f"Invalid n_dims {n_dims}, must be in (1, 2)")

--- a/modelserver/types/api.py
+++ b/modelserver/types/api.py
@@ -272,3 +272,23 @@ class HFFile(BaseModel):
 class ListHFFilesResponse(BaseModel):
     repo: str
     files: list[HFFile]
+
+
+class SavedExperimentIn(BaseModel):
+    model_id: str
+    model_version: SemVer
+    temperature: float
+    tokens: int
+    prompt: str
+    output: str
+
+
+class SavedExperimentOut(BaseModel):
+    experiment_id: str
+    model_id: str
+    model_version: SemVer
+    temperature: float
+    tokens: int
+    prompt: str
+    output: str
+    created_at: datetime


### PR DESCRIPTION
- Implement endpoints for saving, querying and deleting Experiments to be kept by the user
- Actually enable enforcement of foreign key constraints in SQLite, and fix how we're declaring compound FKs
- **Drive-by**: Cleanup our `None` returning endpoints to properly return 204 NO CONTENT instead of 200 with nulls. This should not affect any of the app client code, it just makes things clearer to API consumers
