### PR TITLE
Add async wrapping for completion WebSocket

### DIFF
--- a/modelserver/app.py
+++ b/modelserver/app.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from modelserver.dependencies import persistent_db, task_store
 from modelserver.middleware import StaticReactRouterFiles
-from modelserver.routes import health, hfbrowse, v1
+from modelserver.routes import admin, health, hfbrowse, v1
 from modelserver.tasks import TaskWorker
 
 app = FastAPI(openapi_url="/openapi.yml")
@@ -18,6 +18,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(admin.router)
 app.include_router(v1.router)
 app.include_router(health.router)
 app.include_router(hfbrowse.router)

--- a/modelserver/model_worker.py
+++ b/modelserver/model_worker.py
@@ -1,0 +1,91 @@
+import asyncio
+import logging
+import multiprocessing as M
+import os
+import queue
+from concurrent.futures import ProcessPoolExecutor
+from typing import AsyncGenerator
+
+from llama_cpp import Llama
+
+from modelserver.types.api import CompletionInferenceRequest
+
+"""
+Python asyncio-friendly multiprocessing worker for running llama.cpp models.
+
+This module connects a few related Python 3.x concepts to create a simple way to run models
+without hogging the ports in the foreground:
+
+    1. When a WebSocket comes in, the processing of messages on the WebSocket must be done
+       using async primitives, as the WebSocket library object itself only contains methods
+       that are coroutines.
+    2. We construct a ProcessPoolExecutor to spawn new multiprocessing.Process objects that
+       can execute the llama-cpp-python inference code in a separate Python process. This allows
+       us to completely avoid the GIL issues that arise when trying to use either background
+       threads or the main event loop thread for executing CPU-intensive code.
+    3. We construct a queue.Queue object which serves as a multiprocessing-safe channel to convey
+       data from the subprocess (in this case, live tokens) back up to the parent. The parent
+       wraps this queue using async primitives to then expose an AsyncGenerator interface to users.
+       This allows you to use the tidy `async for token in run_completion_async(...)` syntax.
+"""
+
+
+CHANNEL_SENTINEL = None
+
+logger = logging.getLogger(__name__)
+
+
+def do_completion_llama(
+    model_path: str,
+    prompt: str,
+    tokens: int,
+    temperature: float,
+    channel: queue.Queue[str | None],
+) -> None:
+    """
+    Execute completion, sending the results back over the completion task.
+    """
+    logger.info(f"Initializing model in subprocess {os.getpid()}")
+    llama = Llama(model_path=model_path)
+    for chunk in llama.create_completion(
+        prompt,
+        max_tokens=tokens,
+        temperature=temperature,
+        stream=True,
+    ):
+        channel.put(chunk["choices"][0]["text"])
+    channel.put(CHANNEL_SENTINEL)
+
+
+async def run_completion_async(
+    completion_request: CompletionInferenceRequest,
+    model_path: str,
+) -> AsyncGenerator[str, str]:
+    loop = asyncio.get_running_loop()
+
+    with ProcessPoolExecutor() as pool:
+        with M.Manager() as manager:
+            chan: queue.Queue[str | None] = manager.Queue()
+            res = loop.run_in_executor(
+                pool,
+                do_completion_llama,
+                model_path,
+                completion_request.prompt,
+                completion_request.tokens,
+                completion_request.temperature,
+                chan,
+            )
+            while True:
+                try:
+                    item = chan.get_nowait()
+                    if item == CHANNEL_SENTINEL:
+                        break
+                    yield str(item)
+                except queue.Empty:
+                    # NOTE(aduffy): This is important as this is how we signal in Python to
+                    #  yield to other coroutines, else nothing else in the event loop is able
+                    #  to run while we're polling the queue.
+                    await asyncio.sleep(0)
+                    continue
+            await res
+            return

--- a/modelserver/routes/admin.py
+++ b/modelserver/routes/admin.py
@@ -1,0 +1,18 @@
+import sys
+import threading
+import traceback
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/admin")
+
+
+@router.get("/stack")
+def get_stack_traces() -> dict[str, list[str]]:
+    id2name = dict([(th.ident, th.name) for th in threading.enumerate()])
+    stacks = {}
+    for tid, frame in sys._current_frames().items():
+        stack = traceback.extract_stack(frame).format()
+        tname = id2name[tid]
+        stacks[tname] = stack
+    return stacks

--- a/modelserver/routes/health.py
+++ b/modelserver/routes/health.py
@@ -6,5 +6,5 @@ router = APIRouter()
 
 
 @router.get("/healthz")
-async def get_healthz() -> HealthStatus:
+def get_healthz() -> HealthStatus:
     return HealthStatus(status="ok")


### PR DESCRIPTION
**Before**:

Whenever we were running llama.cpp code, we were actually blocking the main event loop every time we iterated over the completion chunks...:facepalm: This would cause all other request processing to completely halt while any completion requests were outstanding.

The main problem was that we were running this directly on the main event loop thread, but even moving this to a background thread isn't enough because of the GIL, so we actually need to move processing to a separate multiprocessing process. We also need to be careful that in the main event loop that passes data to the background process doesn't accidentally cause blocking behavior with the queue.

**After**:

We have moved llama.cpp completion to a background thread that is spun up on-demand and integrated with the async WebSocket interface.

This has alleviated the issue where completions block processing of any other endpoint logic.

Additionally, I've added an endpoint at `/admin/stack` that dumps a stacktrace of all Python threads as a debugging tool for us to use to inspect the process going forward.