### PR TITLE
task CRUD, invocation

### DIFF
--- a/modelserver/db/_core.py
+++ b/modelserver/db/_core.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
-from uuid import UUID
+
+from pydantic import UUID4
 
 from modelserver.types.api import (
+    CreateTaskRequest,
     ModelVersionInternal,
     RegisteredModel,
     RegisterModelRequest,
     SavedExperimentIn,
     SavedExperimentOut,
     SemVer,
+    TaskInfo,
+    UpdateTaskRequest,
 )
 
 
@@ -29,7 +33,11 @@ class DataManager(ABC):
 
     @abstractmethod
     def get_model_version_internal(
-        self, model_name: str, version: str
+        self,
+        *,
+        version: str,
+        model_name: str | None = None,
+        model_id: str | None = None,
     ) -> ModelVersionInternal:
         """
         Retrieve a single model using its name and version.
@@ -96,4 +104,32 @@ class DataManager(ABC):
         """
         Delete the experiment by ID.
         :param experiment_id: The ID of the saved experiment
+        """
+
+    @abstractmethod
+    def get_tasks(self) -> list[TaskInfo]:
+        """
+        Return a list of registered tasks.
+        """
+
+    @abstractmethod
+    def create_task(self, create_request: CreateTaskRequest) -> UUID4:
+        """
+        Create a new task based on a desired input and output schema.
+        """
+
+    @abstractmethod
+    def update_task(
+        self, task_name: str, update_task_request: UpdateTaskRequest
+    ) -> None:
+        """
+        Request to update the task using a partial version of the task info.
+        """
+
+    @abstractmethod
+    def get_task_by_name(self, task_name: str) -> TaskInfo:
+        """
+        Lookup a task by name.
+
+        :param task_name: The unique name of the task
         """

--- a/modelserver/db/_tables.py
+++ b/modelserver/db/_tables.py
@@ -92,6 +92,25 @@ saved_experiments_table = Table(
     ),
 )
 
+task_def_table = Table(
+    "task_def_v0",
+    metadata_obj,
+    Column("id", String, primary_key=True),
+    Column("name", String, unique=True),
+    Column("created_at", DateTime, nullable=False),
+    Column("updated_at", DateTime, nullable=False),
+    Column("prompt_template", String, nullable=False),
+    Column("input_schema", JSON, nullable=False),
+    Column("output_grammar", String, nullable=True),
+    # A task can be defined but not yet linked to a particular backing model
+    Column("backing_model_id", String, nullable=True),
+    Column("backing_model_version", String, nullable=True),
+    ForeignKeyConstraint(
+        ["backing_model_id", "backing_model_version"],
+        ["model_version.model_id", "model_version.version"],
+    ),
+)
+
 
 """
 Special table that contains all joined attributes of model_version_table, import_metadata_table and model_params_table.

--- a/modelserver/db/test_db.py
+++ b/modelserver/db/test_db.py
@@ -51,7 +51,10 @@ def test_simple_query(db: PersistentDataManager) -> None:
 
     db.register_model(REGISTER_V1)
     assert len(db.get_registered_models()) == 1
-    assert db.get_model_version_internal("anewmodel", "0.1.0") is not None
+    assert (
+        db.get_model_version_internal(model_name="anewmodel", version="0.1.0")
+        is not None
+    )
 
     db.register_model(REGISTER_V2)
     models = db.get_registered_models()
@@ -121,7 +124,9 @@ def test_error_handling(db: PersistentDataManager) -> None:
 
     # Ensure model lookups fail with 404 exception
     with pytest.raises(HTTPException) as http_ex:
-        db.get_model_version_internal(REGISTER_V3.model, str(REGISTER_V3.version))
+        db.get_model_version_internal(
+            model_name=REGISTER_V3.model, version=str(REGISTER_V3.version)
+        )
     assert http_ex.value.status_code == status.HTTP_404_NOT_FOUND
 
 

--- a/modelserver/types/api.py
+++ b/modelserver/types/api.py
@@ -293,3 +293,54 @@ class SavedExperimentOut(BaseModel):
 
 class GetSavedExperimentsResponse(BaseModel):
     experiments: list[SavedExperimentOut]
+
+
+class CreateTaskRequest(BaseModel):
+    name: str
+    # We need a new system for setting this shit up properly...everything else will be none to start with
+
+
+class UpdateTaskRequest(BaseModel):
+    # Make a modification to the task to update it in some way
+    name: str | None
+    model_id: str | None
+    model_version: str | None
+    prompt_template: str | None
+    input_schema: dict[str, str] | None
+    grammar: str | None
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+    )
+
+
+class TaskInfo(BaseModel):
+    name: str
+    task_id: UUID4
+    model_id: UUID4 | None
+    model_version: SemVer | None
+    task_params: dict[str, str]
+    output_grammar: str | None
+    prompt_template: str
+
+    model_config = ConfigDict(
+        protected_namespaces=(),
+    )
+
+
+class TaskInvocationRequest(BaseModel):
+    """
+    A request to invoke a particular Task
+
+    :param variables: A string to string dictionary of variables as provided by the user at request time, must
+                      correspond to the configured variables for the Task.
+    """
+
+    variables: dict[str, str]
+    temperature: float = 0.0
+
+
+class TaskInvocation(BaseModel):
+    task_name: str
+    elapsed_seconds: float
+    result: str

--- a/modelserver/types/workers.py
+++ b/modelserver/types/workers.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class RenderedTaskInvocation(BaseModel):
+    """
+    A rendered and ready to execute task invocation
+
+    :model_path: The path to the cached model file that needs to be loaded to execute the the inference
+    :param rendered_prompt: The fully rendered prompt, with all variables inserted
+    :grammar: The textual representation of grammar in GBNF format (See llama.cpp repo for examples)
+    """
+
+    model_path: str
+    rendered_prompt: str
+    grammar: str | None
+    temperature: float

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ huggingface-hub==0.15.1
 idna==3.4
 iniconfig==2.0.0
 isort==5.12.0
-llama-cpp-python==0.1.68
+llama-cpp-python==0.1.83
 markdown-it-py==3.0.0
 mccabe==0.7.0
 mdurl==0.1.2


### PR DESCRIPTION
Initial API for the Tasks concept.

Tasks are schematized facades on top of swappable models that allow you to encode specific behaviors that are useful for most enterprise use-cases. Tasks are parameterized by

- A **prompt template**, for example `Summarize the following article and emit a JSON list of keywords: {article}\n\nResult:`. Prompt templates will be formatting like Python/Rust template strings referencing all variables between a pair of curly braces
- An **input schema**, which maps and enforces types used to pass data into the **prompt template** at invocation time
- An **output grammar**, this is a context-free grammar that is used at runtime to enforce the produced schema matches

Output grammars should be generated from something easily understandable to a moderately technical user, e.g. TypeScript interfaces, which closely reflect JSON.

We have an existing TypeScript library, https://github.com/intrinsiclabsAI/gbnfgen, which allows compiling a schema into a llamacpp ready grammar text format.


## Next

* FE wiring
* Type-checking for the variables provided to `TaskInvocationRequest`s
