### PR TITLE
Add CLI scripts

### DIFF
--- a/modelserver/app.py
+++ b/modelserver/app.py
@@ -46,7 +46,7 @@ def on_shutdown() -> None:
     pass
 
 
-def entrypoint():
+def entrypoint() -> None:
     import uvicorn
 
     uvicorn.run(app=app, port=8000, host="0.0.0.0")

--- a/modelserver/app.py
+++ b/modelserver/app.py
@@ -44,3 +44,9 @@ def on_startup() -> None:
 def on_shutdown() -> None:
     # TODO(aduffy): gracefully kill worker
     pass
+
+
+def entrypoint():
+    import uvicorn
+
+    uvicorn.run(app=app, port=8000, host="0.0.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ description = ""
 authors = ["Andrew Duffy <andrew@intrinsiclabs.ai>"]
 readme = "README.md"
 
+[tool.poetry.scripts]
+modelserver = "modelserver.app:entrypoint"
+workerserver = "workerserver.worker:entrypoint"
+
 [tool.poetry.dependencies]
 python = "^3.11"
 pydantic = "^2.4.2"

--- a/workerserver/worker.py
+++ b/workerserver/worker.py
@@ -156,7 +156,7 @@ async def run_loop() -> None:
             time.sleep(10.0)
 
 
-def entrypoint():
+def entrypoint() -> None:
     asyncio.run(run_loop())
 
 

--- a/workerserver/worker.py
+++ b/workerserver/worker.py
@@ -156,5 +156,9 @@ async def run_loop() -> None:
             time.sleep(10.0)
 
 
-if __name__ == "__main__":
+def entrypoint():
     asyncio.run(run_loop())
+
+
+if __name__ == "__main__":
+    entrypoint()


### PR DESCRIPTION
Add entrypoint scripts, as per https://setuptools.pypa.io/en/latest/userguide/entry_point.html

```
# Install our entrypoint scripts. This will generate two CLI bindings, one called `modelserver` and one called `workerserver`
$ poetry install
$ poetry run modelserver
INFO:     Started server process [20486]
INFO:     Waiting for application startup.
INFO     Started background thread
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)


$ poetry run workerserver
INFO     booting remoteworker with config WorkerConfig(worker_id='worker1', modelserver_url='http://localhost:8000', hf_token='hf_REDACTED')
WARNING  ConnectError: http://localhost:8000 not yet available
WARNING  ConnectError: http://localhost:8000 not yet available
```