### PR TITLE
bump grammar generator, fix half-precision

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,18 @@
+name: Autorelease main with minor version bumps
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Autorelease Trigger
+        id: autorelease
+        uses: a10y/autorelease-action@0.1.0
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
                 "@blueprintjs/core": "^5.3.0",
                 "@headlessui/react": "^1.7.17",
                 "@heroicons/react": "^2.0.18",
-                "@intrinsicai/gbnfgen": "^0.6.0",
+                "@intrinsicai/gbnfgen": "^0.10.0",
                 "@reduxjs/toolkit": "^1.9.5",
                 "@tailwindcss/forms": "^0.5.3",
                 "@tailwindcss/typography": "^0.5.9",
@@ -1000,9 +1000,12 @@
             "dev": true
         },
         "node_modules/@intrinsicai/gbnfgen": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@intrinsicai/gbnfgen/-/gbnfgen-0.6.0.tgz",
-            "integrity": "sha512-vaE6/GCrgM7/XquaeBjrgZMnytvJsvTD5dEQtNf9ocWUIZNn+dtkNVCe5rkxBReHzYimc+Brnk6682ouvf6+jA=="
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@intrinsicai/gbnfgen/-/gbnfgen-0.10.0.tgz",
+            "integrity": "sha512-YQ/zowF7oYKe5vFU21BQjSJl1mMXFiosaSJiGgLFPmt2rGkD358B28jvJpUOYekuaDJJg1jIXzy5dt/pcx2RfA==",
+            "dependencies": {
+                "ts-morph": "^20.0.0"
+            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.3",
@@ -1165,6 +1168,39 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/@ts-morph/common": {
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.21.0.tgz",
+            "integrity": "sha512-ES110Mmne5Vi4ypUKrtVQfXFDtCsDXiUiGxF6ILVlE90dDD4fdpC1LSjydl/ml7xJWKSDZwUYD2zkOePMSrPBA==",
+            "dependencies": {
+                "fast-glob": "^3.2.12",
+                "minimatch": "^7.4.3",
+                "mkdirp": "^2.1.6",
+                "path-browserify": "^1.0.1"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/minimatch": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@types/babel__core": {
@@ -2066,6 +2102,11 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/code-block-writer": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+            "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w=="
         },
         "node_modules/color-convert": {
             "version": "1.9.3",
@@ -4146,6 +4187,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/mkdirp": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+            "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/mri": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -4418,6 +4473,11 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
         },
         "node_modules/path-case": {
             "version": "3.0.4",
@@ -5538,6 +5598,15 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+        },
+        "node_modules/ts-morph": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-20.0.0.tgz",
+            "integrity": "sha512-JVmEJy2Wow5n/84I3igthL9sudQ8qzjh/6i4tmYCm6IqYyKFlNbJZi7oBdjyqcWSWYRu3CtL0xbT6fS03ESZIg==",
+            "dependencies": {
+                "@ts-morph/common": "~0.21.0",
+                "code-block-writer": "^12.0.0"
+            }
         },
         "node_modules/tslib": {
             "version": "1.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
         "@blueprintjs/core": "^5.3.0",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
-        "@intrinsicai/gbnfgen": "^0.6.0",
+        "@intrinsicai/gbnfgen": "^0.10.0",
         "@reduxjs/toolkit": "^1.9.5",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",

--- a/frontend/src/pages/Task.tsx
+++ b/frontend/src/pages/Task.tsx
@@ -11,7 +11,7 @@ import {
     useUpdateTaskModelMutation,
     useUpdateTaskPromptMutation,
 } from "../api/services/v1";
-import { compile, serializeGrammar } from "@intrinsicai/gbnfgen";
+import { compileSync, serializeGrammar } from "@intrinsicai/gbnfgen";
 import ts from "typescript";
 
 import Page from "../components/layout/Page";
@@ -200,7 +200,7 @@ function TaskValidation({ task }: { task: TaskInfo }) {
                     ifaces.push(child.name.getText(srcFile));
                 }
             });
-            const grammarArray = compile(taskGrammar, ifaces[0]);
+            const grammarArray = compileSync(taskGrammar, ifaces[0]);
             const grammarFile = serializeGrammar(grammarArray);
 
             updateGrammarModelAction({


### PR DESCRIPTION
Bumps gbnfgen dependency (used in the Task UI for grammar entry) to latest, which brings us support for string enums in Task outputs.

Also fixing a bug I found in prod: half-precision tuning only works with CUDA/MPS, flag that when we decide how to load the model in the finetuning codepath.